### PR TITLE
Add support for pipes and file descriptors

### DIFF
--- a/bin/rustt
+++ b/bin/rustt
@@ -8,6 +8,11 @@ usage() {
 SOURCE="$1"
 SOURCE_BASE="$(basename "$SOURCE")"
 
+if [[ "$SOURCE" == "-" ]]
+then
+   SOURCE="/dev/fd/0"
+fi
+
 if [[ ! -p "$SOURCE" ]] && [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
 then
    usage

--- a/bin/rustt
+++ b/bin/rustt
@@ -8,8 +8,8 @@ usage() {
 SOURCE="$1"
 SOURCE_BASE="$(basename "$SOURCE")"
 
-if [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
-then 
+if [[ ! -p "$SOURCE" ]] && [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
+then
    usage
    exit 1
 fi

--- a/bin/rustx
+++ b/bin/rustx
@@ -8,6 +8,11 @@ usage() {
 SOURCE="$1"
 SOURCE_BASE="$(basename "$SOURCE")"
 
+if [[ "$SOURCE" == "-" ]]
+then
+   SOURCE="/dev/fd/0"
+fi
+
 if [[ ! -p "$SOURCE" ]] && [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
 then
    usage

--- a/bin/rustx
+++ b/bin/rustx
@@ -8,8 +8,8 @@ usage() {
 SOURCE="$1"
 SOURCE_BASE="$(basename "$SOURCE")"
 
-if [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
-then 
+if [[ ! -p "$SOURCE" ]] && [[ ! "${SOURCE_BASE#*.}" == "rs" ]]
+then
    usage
    exit 1
 fi


### PR DESCRIPTION
This PR allows `rustx` and `rustt` to be used in the following ways:

``` sh
# $ cat file.rs
# fn main() { println!("Hello, wrold!"); }

$ rustx <(cat file.rs)
Hello, wrold!
$ cat file.rs | rustx -
Hello, wrold!
```

This is useful e.g. for running Rust scripts from the clipboard on OS X using the [pbpaste](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/pbpaste.1.html) utility.
